### PR TITLE
Fix: Add validation for name length

### DIFF
--- a/vibe-app/src/app/api/users/route.ts
+++ b/vibe-app/src/app/api/users/route.ts
@@ -15,6 +15,14 @@ export async function POST(req: NextRequest) {
       )
     }
 
+    if (name.length > 255) {
+      return NextResponse.json(
+        { message: 'Name must be at most 255 characters' },
+        { status: 400 }
+      )
+    }
+
+
     if (!isValidEmail(email)) {
       return NextResponse.json({ message: 'Invalid email' }, { status: 400 })
     }


### PR DESCRIPTION
This PR adds a validation check for the name field length in the registration API to prevent database 'P2000' errors when the input exceeds the 255-character limit defined in the schema.